### PR TITLE
Fix for issue 26: Click CLI not working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+venv/
 
 .idea/
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ print(f"{n}{km.abbr} in {mile} = {km.to_unit(n, mile)}")
 
 ### CLI
 
+The converter can also be run as a command-line tool.
+Once it's been installed, it can be run in your terminal as:
+
+```bash
+oxrse-unit-conv 42 km mile
+```
+
+Help is available using:
+
+```bash
+oxrse-unit-conv --help
+```
+
+
+
 ## Development
 
 ### Structure

--- a/README.md
+++ b/README.md
@@ -33,11 +33,9 @@ Units are converted to one another by asking one unit to convert to the other.
 The `Unit.to_unit` function takes a number and a target `Unit`.
 
 ```python
-import oxrse_unit_conv
+from oxrse_unit_conv import km, mile
 
 n = 42
-km = oxrse_unit_conv.km
-mile = oxrse_unit_conv.mile
 print(f"{n}{km.abbr} in {mile} = {km.to_unit(n, mile)}")
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,17 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+dependencies = [
+  "click"
+]
+
+[project.scripts]
+oxrse-unit-conv = "oxrse_unit_conv.main:click_convert"
 
 [project.urls]
 "Homepage" = "https://github.com/OxfordRSE/oxrse_unit_conv"
 "Bug Tracker" = "https://github.com/OxfordRSE/oxrse_unit_conv/issues"
+
 
 [build-system]
 requires = ["hatchling"]

--- a/src/oxrse_unit_conv/__init__.py
+++ b/src/oxrse_unit_conv/__init__.py
@@ -1,2 +1,2 @@
-from .units import *
-from .main import convert, click_convert
+from oxrse_unit_conv.units import *
+from oxrse_unit_conv.main import convert, click_convert

--- a/src/oxrse_unit_conv/main.py
+++ b/src/oxrse_unit_conv/main.py
@@ -1,6 +1,6 @@
 # Click interface to allow running from command line
-import units
-import meta.classes
+from oxrse_unit_conv import units
+from oxrse_unit_conv.meta import classes
 import click
 import logging
 
@@ -25,15 +25,15 @@ def click_convert(number, unit, to):
     click.echo(convert(number, unit, to))
 
 
-def convert(number: meta.classes.Number, unit: str, to: str):
+def convert(number: classes.Number, unit: str, to: str):
     logging.debug(f"Call: {number}: {unit} -> {to}")
 
     my_unit: units.Unit = getattr(units, unit)
-    if not isinstance(my_unit, meta.classes.BaseUnit):
+    if not isinstance(my_unit, classes.BaseUnit):
         raise TypeError(f"{unit} does not correspond to a known unit.")
     if to:
         target_unit = getattr(units, to)
-        if not isinstance(target_unit, meta.classes.BaseUnit):
+        if not isinstance(target_unit, classes.BaseUnit):
             raise TypeError(f"{to} does not correspond to a known unit.")
     else:
         target_unit = my_unit.si_unit

--- a/src/oxrse_unit_conv/si.py
+++ b/src/oxrse_unit_conv/si.py
@@ -5,7 +5,7 @@
 # the first unit is converted to the SI unit,
 # and then the SI unit is converted to the second unit.
 
-from meta import classes
+from oxrse_unit_conv.meta import classes
 
 second = classes.SIUnit("second", "s")
 s = second

--- a/src/oxrse_unit_conv/units.py
+++ b/src/oxrse_unit_conv/units.py
@@ -1,5 +1,5 @@
-from si import *
-from meta.classes import Unit
+from oxrse_unit_conv.si import *
+from oxrse_unit_conv.meta.classes import Unit
 
 # second
 minute = Unit(name='minute', abbr='min', si=second, to_si_fun=lambda n: n * 60)

--- a/src/tests/test_conversion_core.py
+++ b/src/tests/test_conversion_core.py
@@ -1,6 +1,6 @@
 import unittest
 from oxrse_unit_conv.meta import classes
-from oxrse_unit_conv import kilometer, m, m2, m3, s, hour
+from oxrse_unit_conv.units import kilometer, m, m2, m3, s, hour
 
 
 class TestConversionCore(unittest.TestCase):


### PR DESCRIPTION
This should fix issue #26 - it adds the missing dependency on Click to the pyproject file, and adds the main script's click function as a command-line utility `oxrse-unit-conv`.

Will depend on #27 being merged to switch to package-style imports so the click script will work.